### PR TITLE
Allow dictionaries to be nil

### DIFF
--- a/lib/token_phrase/generator.rb
+++ b/lib/token_phrase/generator.rb
@@ -26,7 +26,7 @@ module TokenPhrase
     end
 
     def lists
-      dictionary.values_at(*order)
+      dictionary.values_at(*order).compact
     end
   end
 end


### PR DESCRIPTION
Nil dictionaries don't insert a separator into the generated token.
